### PR TITLE
feat: Implement analytics dashboard and failing API tests

### DIFF
--- a/server/db/schema.prisma
+++ b/server/db/schema.prisma
@@ -8,3 +8,4 @@
 @@import("./models/VerificationToken.prisma")
 @@import("./models/Media.prisma")
 @@import("./models/Outbox.prisma")
+@@import("./models/DevOpsMetric.prisma")

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+    '^.+\\.(js|jsx|ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
 };

--- a/server/models/DevOpsMetric.prisma
+++ b/server/models/DevOpsMetric.prisma
@@ -1,0 +1,7 @@
+model DevOpsMetric {
+  id        String   @id @default(cuid())
+  type      String
+  payload   String   @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/server/pages/analytics/AnalyticsDashboard.tsx
+++ b/server/pages/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import KpiDashboard from './components/KpiDashboard';
+
+async function getMetrics() {
+  // This fetch call will be executed on the server
+  const res = await fetch('http://localhost:3000/api/analytics/devops', { cache: 'no-store' });
+  if (!res.ok) {
+    // This will activate the closest `error.js` Error Boundary
+    throw new Error('Failed to fetch data');
+  }
+  return res.json();
+}
+
+export default async function AnalyticsDashboard() {
+  const metrics = await getMetrics();
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Analytics Dashboard</h1>
+      <KpiDashboard metrics={metrics} />
+    </div>
+  );
+}

--- a/server/pages/analytics/components/KpiDashboard.tsx
+++ b/server/pages/analytics/components/KpiDashboard.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from 'react';
+
+interface KpiDashboardProps {
+  metrics: any[];
+}
+
+const KpiDashboard: React.FC<KpiDashboardProps> = ({ metrics }) => {
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">KPI Dashboard</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {metrics.map((metric) => (
+          <div key={metric.id} className="p-4 border rounded-lg">
+            <h3 className="font-bold">{metric.type}</h3>
+            <pre className="mt-2 bg-gray-100 p-2 rounded">
+              {JSON.stringify(JSON.parse(metric.payload), null, 2)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default KpiDashboard;

--- a/server/pages/api/analytics/devops.ts
+++ b/server/pages/api/analytics/devops.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'GET') {
+    const metrics = await prisma.devOpsMetric.findMany();
+    res.status(200).json(metrics);
+  } else if (req.method === 'POST') {
+    const { type, payload } = req.body;
+    const newMetric = await prisma.devOpsMetric.create({
+      data: {
+        type,
+        payload: JSON.stringify(payload),
+      },
+    });
+    res.status(201).json(newMetric);
+  } else {
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/server/server/package-lock.json
+++ b/server/server/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/tests/pages/api/analytics/devops.test.ts
+++ b/server/tests/pages/api/analytics/devops.test.ts
@@ -1,0 +1,39 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/analytics/devops';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+describe('/api/analytics/devops', () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('should return a 500 error when fetching metrics', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+
+  it('should return a 500 error when creating a metric', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        type: 'CRASH',
+        payload: {
+          errorMessage: 'Test error',
+          stackTrace: 'Test stack trace',
+          severity: 'critical',
+        },
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/auth/provider-signin.test.ts
+++ b/server/tests/pages/api/auth/provider-signin.test.ts
@@ -1,0 +1,17 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/auth/provider-signin';
+
+describe('/api/auth/provider-signin', () => {
+  it('should return a 500 error when signing in with a provider', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        provider: 'google',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/auth/register.test.ts
+++ b/server/tests/pages/api/auth/register.test.ts
@@ -1,0 +1,19 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/auth/register';
+
+describe('/api/auth/register', () => {
+  it('should return a 500 error when registering a user', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'password',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/auth/request-password-reset.test.ts
+++ b/server/tests/pages/api/auth/request-password-reset.test.ts
@@ -1,0 +1,17 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/auth/request-password-reset';
+
+describe('/api/auth/request-password-reset', () => {
+  it('should return a 500 error when requesting a password reset', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        email: 'test@example.com',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/auth/reset-password.test.ts
+++ b/server/tests/pages/api/auth/reset-password.test.ts
@@ -1,0 +1,18 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/auth/reset-password';
+
+describe('/api/auth/reset-password', () => {
+  it('should return a 500 error when resetting a password', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        token: 'test-token',
+        password: 'new-password',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/daily-quiz/answer.test.ts
+++ b/server/tests/pages/api/daily-quiz/answer.test.ts
@@ -1,0 +1,18 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/daily-quiz/answer';
+
+describe('/api/daily-quiz/answer', () => {
+  it('should return a 500 error when submitting an answer', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        questionId: '1',
+        answerId: '1',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/daily-quiz/events.test.ts
+++ b/server/tests/pages/api/daily-quiz/events.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/daily-quiz/events';
+
+describe('/api/daily-quiz/events', () => {
+  it('should return a 500 error when fetching events', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/daily-quiz/results.test.ts
+++ b/server/tests/pages/api/daily-quiz/results.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/daily-quiz/results';
+
+describe('/api/daily-quiz/results', () => {
+  it('should return a 500 error when fetching results', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/daily-quiz/session.test.ts
+++ b/server/tests/pages/api/daily-quiz/session.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/daily-quiz/session';
+
+describe('/api/daily-quiz/session', () => {
+  it('should return a 500 error when fetching the session', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/engagement/achievements.test.ts
+++ b/server/tests/pages/api/engagement/achievements.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/engagement/achievements';
+
+describe('/api/engagement/achievements', () => {
+  it('should return a 500 error when fetching achievements', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/engagement/leaderboard.test.ts
+++ b/server/tests/pages/api/engagement/leaderboard.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/engagement/leaderboard';
+
+describe('/api/engagement/leaderboard', () => {
+  it('should return a 500 error when fetching the leaderboard', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/engagement/user-engagement/[userId].test.ts
+++ b/server/tests/pages/api/engagement/user-engagement/[userId].test.ts
@@ -1,0 +1,17 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../../pages/api/engagement/user-engagement/[userId]';
+
+describe('/api/engagement/user-engagement/[userId]', () => {
+  it('should return a 500 error when fetching user engagement', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        userId: '1',
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/engagement/weekly-king.test.ts
+++ b/server/tests/pages/api/engagement/weekly-king.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/engagement/weekly-king';
+
+describe('/api/engagement/weekly-king', () => {
+  it('should return a 500 error when fetching the weekly king', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/learning/featured-categories.test.ts
+++ b/server/tests/pages/api/learning/featured-categories.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/learning/featured-categories';
+
+describe('/api/learning/featured-categories', () => {
+  it('should return a 500 error when fetching featured categories', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/learning/questions.test.ts
+++ b/server/tests/pages/api/learning/questions.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../../pages/api/learning/questions';
+
+describe('/api/learning/questions', () => {
+  it('should return a 500 error when fetching questions', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/server/tests/pages/api/sync.test.ts
+++ b/server/tests/pages/api/sync.test.ts
@@ -1,0 +1,14 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../../../pages/api/sync';
+
+describe('/api/sync', () => {
+  it('should return a 500 error when syncing', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});


### PR DESCRIPTION
This commit introduces a new analytics dashboard with a KPI component to track DevOps metrics. It also adds a new `DevOpsMetric` model to the database schema and a corresponding API endpoint to manage the metrics.

Additionally, this commit includes a suite of failing API acceptance tests for all the endpoints under `/api`. These tests are designed to fail initially and will be fixed in a subsequent commit.

Note: The test runner is currently not working due to a configuration issue with Jest and ts-jest. The tests have been written but could not be executed successfully.